### PR TITLE
Fix deprecation warnings

### DIFF
--- a/docker-compose.gemspec
+++ b/docker-compose.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "backticks", "~> 0.3"
+  spec.add_dependency "backticks", "~> 0.4"
 
   spec.add_development_dependency "bundler", "~> 1.10"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/lib/docker/compose/session.rb
+++ b/lib/docker/compose/session.rb
@@ -103,7 +103,7 @@ module Docker::Compose
       }
 
       Dir.chdir(@dir) do
-        cmd = @shell.command('docker-compose', project_opts, *args).join
+        cmd = @shell.run('docker-compose', project_opts, *args).join
         status, out, err = cmd.status, cmd.captured_output, cmd.captured_error
         status.success? || raise(Error.new(args.first, status, err))
         out

--- a/spec/docker/compose/session_spec.rb
+++ b/spec/docker/compose/session_spec.rb
@@ -12,22 +12,22 @@ describe Docker::Compose::Session do
 
   before do
     allow(status).to receive(:success?).and_return(exitstatus == 0)
-    allow(shell).to receive(:command).and_return(command)
+    allow(shell).to receive(:run).and_return(command)
     allow(command).to receive(:join).and_return(command)
   end
 
   describe '.new' do
     it 'allows file override' do
       s1 = described_class.new(shell, file: 'foo.yml')
-      expect(shell).to receive(:command).with('docker-compose', {file: 'foo.yml'}, anything, anything, anything)
+      expect(shell).to receive(:run).with('docker-compose', {file: 'foo.yml'}, anything, anything, anything)
       s1.up
     end
   end
 
   describe '#up' do
     it 'runs containers' do
-      expect(shell).to receive(:command).with('docker-compose', anything, 'up', anything, anything)
-      expect(shell).to receive(:command).with('docker-compose', anything, 'up', hash_including(d:true), anything)
+      expect(shell).to receive(:run).with('docker-compose', anything, 'up', anything, anything)
+      expect(shell).to receive(:run).with('docker-compose', anything, 'up', hash_including(d:true), anything)
       session.up
       session.up detached:true
     end


### PR DESCRIPTION
With `backticks` 0.4 every `Docker::Compose` method prints out a deprecation warning: "Backticks::Runner#command is deprecated".  I'm using `Docker::Compose` in a test suite so this produces quite a lot of spam to the console.

This fixes the deprecation warning, and should not otherwise affect any behaviour, since `#command` is just a deprecated wrapper for `#run`.  Just in case, it also explicitly sets the dependency on `backticks` to 0.4, so as not to depend on any older difference in behaviour between the two methods.