### PR TITLE
Fix ports list in containers, leading whitespace due to split

### DIFF
--- a/lib/docker/compose/container.rb
+++ b/lib/docker/compose/container.rb
@@ -40,7 +40,7 @@ module Docker::Compose
 
       names = names.split(',') if names.is_a?(String)
       labels = labels.split(',') if labels.is_a?(String)
-      ports = ports.split(',') if ports.is_a?(String)
+      ports = ports.split(',').map{ |x| x.strip } if ports.is_a?(String)
 
       @id = id
       @image = image


### PR DESCRIPTION
Before (note whitespace in item 1):

```
[
    [0] "0.0.0.0:9200->9200/tcp",
    [1] " 9300/tcp"
]
```

After:

```
[
    [0] "0.0.0.0:9200->9200/tcp",
    [1] "9300/tcp"
]
```