### PR TITLE
Buffer compose stderr by default; upgrade Backticks

### DIFF
--- a/docker-compose.gemspec
+++ b/docker-compose.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'backticks', '~> 0.4'
+  spec.add_dependency 'backticks', '~> 0.5'
 
   spec.add_development_dependency 'bundler', '~> 1.10'
   spec.add_development_dependency 'rake', '~> 10.0'

--- a/lib/docker/compose/session.rb
+++ b/lib/docker/compose/session.rb
@@ -17,7 +17,7 @@ module Docker::Compose
   class Session
     attr_reader :dir, :file
 
-    def initialize(shell = Backticks::Runner.new(interactive: true),
+    def initialize(shell = Backticks::Runner.new(buffered:[:stderr], interactive: true),
                    dir:Dir.pwd, file:'docker-compose.yml')
       @shell = shell
       @dir = dir

--- a/spec/docker/compose/session_spec.rb
+++ b/spec/docker/compose/session_spec.rb
@@ -1,5 +1,5 @@
 describe Docker::Compose::Session do
-  let(:shell) { double('shell') }
+  let(:shell) { double('shell', interactive: false) }
   subject(:session) { described_class.new(shell) }
 
   let(:exitstatus) { 0 }
@@ -36,6 +36,7 @@ describe Docker::Compose::Session do
                      captured_error:'')
         allow(cmd).to receive(:join).and_return(cmd)
         expect(shell).to receive(:run).with('docker', 'ps', hash_including(f:"id=#{h}")).and_return(cmd)
+        allow(shell).to receive(:interactive=)
       end
     end
 
@@ -55,8 +56,8 @@ describe Docker::Compose::Session do
 
   describe '#rm' do
     it 'removes containers' do
-      expect(shell).to receive(:run).with('docker-compose', anything, 'rm', hash_including(f:false,v:false,a:true), [])
-      expect(shell).to receive(:run).with('docker-compose', anything, 'rm', hash_including(f:false,v:false,a:true), ['joebob'])
+      expect(shell).to receive(:run).with('docker-compose', anything, 'rm', hash_including(f:false,v:false), [])
+      expect(shell).to receive(:run).with('docker-compose', anything, 'rm', hash_including(f:false,v:false), ['joebob'])
       expect(shell).to receive(:run).with('docker-compose', anything, 'rm', hash_including(f:true,v:true), [])
       session.rm
       session.rm 'joebob'


### PR DESCRIPTION
Allows @kcboschert to fix an issue with stdin PTYs not working correctly in CI. The gem remains interactive by default (to preserve interface compatibility), but the user can now control interactivity by passing a different shell object:
```
# only stdout will be PTY-based
shell = Backticks::Runner.new(buffered:[:stdin, :stderr])
sess = Docker::Compose::Session.new(shell)

# or, NOTHING will be PTY-based
shell = Backticks::Runner.new(buffered:true)
sess = Docker::Compose::Session.new(shell)
