### PR TITLE
Added #scale method to Docker::Compose::Session

### DIFF
--- a/lib/docker/compose/session.rb
+++ b/lib/docker/compose/session.rb
@@ -87,6 +87,15 @@ module Docker::Compose
       true
     end
 
+    # Idempotently scales the number of containers for given services in the project.
+    # @param [Hash] container_count per service, e.g. {web: 2, worker: 3}
+    # @param [Integer] timeout how long to wait for each service to scale
+    def scale(container_count, timeout: 10)
+      args = container_count.map {|service, count| "#{service}=#{count}"}
+      o = opts(timeout: [timeout, 10])
+      run!('scale', o, *args)
+    end
+
     # Take the stack down
     def down
       run!('down')

--- a/spec/docker/compose/session_spec.rb
+++ b/spec/docker/compose/session_spec.rb
@@ -81,6 +81,17 @@ describe Docker::Compose::Session do
     end
   end
 
+  describe '#scale' do
+    it 'scales containers' do
+      expect(shell).to receive(:run).with('docker-compose', 'scale', {}, 'service1=2')
+      expect(shell).to receive(:run).with('docker-compose', 'scale', {}, 'service1=3', 'service2=4')
+      expect(shell).to receive(:run).with('docker-compose', 'scale', { timeout: 3 }, 'service1=1')
+      session.scale(service1: 2)
+      session.scale(service1: 3, service2: 4)
+      session.scale({ service1: 1 }, timeout: 3)
+    end
+  end
+
   describe '#rm' do
     it 'removes containers' do
       expect(shell).to receive(:run).with('docker-compose', 'rm', {}, [])


### PR DESCRIPTION
Support for docker-compose scale implemented:

```
$  docker-compose scale -h
Set number of containers to run for a service.

Numbers are specified in the form `service=num` as arguments.
For example:

    $ docker-compose scale web=2 worker=3

Usage: scale [options] [SERVICE=NUM...]

Options:
  -t, --timeout TIMEOUT      Specify a shutdown timeout in seconds.
                             (default: 10)
```