### PR TITLE
Added support for no-tty mode for "docker run"

### DIFF
--- a/lib/docker/compose/session.rb
+++ b/lib/docker/compose/session.rb
@@ -121,9 +121,10 @@ module Docker::Compose
     #   running the services that they depend on
     # @param [Array] env a list of environment variables (see: -e flag)
     # @param [Boolean] rm remove the container when done
+    # @param [Boolean] no_tty disable pseudo-tty allocation (see: -T flag)
     # @raise [Error] if command fails
-    def run(service, *cmd, detached: false, no_deps: false, env: [], rm: false)
-      o = opts(detached: [detached, false], no_deps: [no_deps, false], env: [env, []], rm: [rm, false])
+    def run(service, *cmd, detached: false, no_deps: false, env: [], rm: false, no_tty: false)
+      o = opts(d: [detached, false], no_deps: [no_deps, false], env: [env, []], rm: [rm, false], T: [no_tty, false])
       env_params = env.map { |v| { e: v } }
       run!('run', o, *env_params, service, cmd)
     end

--- a/spec/docker/compose/session_spec.rb
+++ b/spec/docker/compose/session_spec.rb
@@ -81,6 +81,15 @@ describe Docker::Compose::Session do
     end
   end
 
+  describe '#run' do
+    it 'runs containers' do
+      expect(shell).to receive(:run).with('docker-compose', 'run', {}, 'service1', [])
+      expect(shell).to receive(:run).with('docker-compose', 'run', hash_including(d:true,T:true), 'service1', %w(command command_args))
+      session.run('service1')
+      session.run('service1', 'command', 'command_args', no_tty: true, detached: true)
+    end
+  end
+
   describe '#scale' do
     it 'scales containers' do
       expect(shell).to receive(:run).with('docker-compose', 'scale', {}, 'service1=2')


### PR DESCRIPTION
This error is raised by docker-compose during execution of the following code on remote machine via ssh (e.g. GoCD build agents):

```ruby
Docker::Compose.new.run(:image_name, *container_args)
```
 
Stacktrace:

```
13:53:24.998 Traceback (most recent call last):
13:53:24.998   File "/usr/bin/docker-compose", line 11, in <module>
13:53:24.998     sys.exit(main())
13:53:24.998   File "/usr/lib/python2.7/dist-packages/compose/cli/main.py", line 64, in main
13:53:25.015     command()
13:53:25.015   File "/usr/lib/python2.7/dist-packages/compose/cli/main.py", line 116, in perform_command
13:53:25.015     handler(command, command_options)
13:53:25.015   File "/usr/lib/python2.7/dist-packages/compose/cli/main.py", line 712, in run
13:53:25.015     run_one_off_container(container_options, self.project, service, options)
13:53:25.015   File "/usr/lib/python2.7/dist-packages/compose/cli/main.py", line 1031, in run_one_off_container
13:53:25.015     pty.start(sockets)
13:53:25.015   File "/usr/lib/python2.7/dist-packages/dockerpty/pty.py", line 334, in start
13:53:25.015     self._hijack_tty(pumps)
13:53:25.015   File "/usr/lib/python2.7/dist-packages/dockerpty/pty.py", line 373, in _hijack_tty
13:53:25.015     pump.flush()
13:53:25.015   File "/usr/lib/python2.7/dist-packages/dockerpty/io.py", line 378, in flush
13:53:25.015     raise e
13:53:25.015 OSError: [Errno 5] Input/output error
```

"docker-compose run" supports "-T" flag, that disables pseudo-tty allocation: https://docs.docker.com/compose/reference/run/

The issue is not reproducible, if -T flag is passed to `docker-compose run`. This PR adds a support of `no_tty` option to `Docker::Compose::Session#run` instance method