### PR TITLE
Added support for overriding mounted volumes in Session#run

### DIFF
--- a/lib/docker/compose/session.rb
+++ b/lib/docker/compose/session.rb
@@ -120,14 +120,16 @@ module Docker::Compose
     # @param [Boolean] no_deps if true, just run specified services without
     #   running the services that they depend on
     # @param [Array] env a list of environment variables (see: -e flag)
+    # @param [Array] volumes a list of volumes to bind mount (see: -v flag)
     # @param [Boolean] rm remove the container when done
     # @param [Boolean] no_tty disable pseudo-tty allocation (see: -T flag)
     # @param [String] user run as specified username or uid (see: -u flag)
     # @raise [Error] if command fails
-    def run(service, *cmd, detached: false, no_deps: false, env: [], rm: false, no_tty: false, user: nil)
+    def run(service, *cmd, detached: false, no_deps: false, volumes: [], env: [], rm: false, no_tty: false, user: nil)
       o = opts(d: [detached, false], no_deps: [no_deps, false], rm: [rm, false], T: [no_tty, false], u: [user, nil])
       env_params = env.map { |v| { e: v } }
-      run!('run', o, *env_params, service, cmd)
+      volume_params = volumes.map { |v| { v: v } }
+      run!('run', o, *env_params, *volume_params, service, cmd)
     end
 
     def restart(*services, timeout:10)

--- a/spec/docker/compose/session_spec.rb
+++ b/spec/docker/compose/session_spec.rb
@@ -105,6 +105,13 @@ describe Docker::Compose::Session do
       expect(shell).to receive(:run).with('docker-compose', 'run', {}, { e:'VAR1=val1' }, { e:'VAR2=val2'}, 'service1', [])
       session.run('service1', env: ["VAR1=val1", "VAR2=val2"])
     end
+
+    it 'runs containers with mounted volumes' do
+      expect(shell).to receive(:run).with('docker-compose', 'run', {}, { v:'/host1:/container1' }, 'service1', [])
+      session.run('service1', volumes: ['/host1:/container1'])
+      expect(shell).to receive(:run).with('docker-compose', 'run', {}, { v:'/host1:/container1' }, { v:'/host2:/container2' }, 'service1', [])
+      session.run('service1', volumes: ['/host1:/container1', '/host2:/container2'])
+    end
   end
 
   describe '#scale' do


### PR DESCRIPTION
`docker-compose run` supports the following flag to override volumes defined in docker-compose.yml:
   ```
 -v, --volume=[]       Bind mount a volume (default [])
```
This PR adds an optional `volumes:` argument to `Session#run` to allow overriding mounted volumes