### PR TITLE
Adding the `no_start` option to `up`

### DIFF
--- a/lib/docker/compose/session.rb
+++ b/lib/docker/compose/session.rb
@@ -77,12 +77,14 @@ module Docker::Compose
     # @return [true] always returns true
     # @raise [Error] if command fails
     def up(*services,
-           detached: false, timeout: 10, build: false, no_build: false, no_deps: false)
+           detached: false, timeout: 10, build: false, no_build: false, no_deps: false,
+           no_start: false)
       o = opts(d: [detached, false],
                timeout: [timeout, 10],
                build: [build, false],
                no_build: [no_build, false],
-               no_deps: [no_deps, false])
+               no_deps: [no_deps, false],
+               no_start: [no_start, false])
       run!('up', o, services)
       true
     end

--- a/spec/docker/compose/session_spec.rb
+++ b/spec/docker/compose/session_spec.rb
@@ -84,8 +84,10 @@ describe Docker::Compose::Session do
     it 'runs containers' do
       expect(shell).to receive(:run).with('docker-compose', 'up', {}, [])
       expect(shell).to receive(:run).with('docker-compose', 'up', hash_including(d:true,timeout:3), [])
+      expect(shell).to receive(:run).with('docker-compose', 'up', hash_including(no_start:true), [])
       session.up
       session.up detached:true, timeout:3
+      session.up no_start:true
     end
   end
 


### PR DESCRIPTION
Handy to create the containers without starting them yet