### PR TITLE
Add option to remove named volumes when calling Docker::Compose::Session#down

### DIFF
--- a/lib/docker/compose/session.rb
+++ b/lib/docker/compose/session.rb
@@ -99,8 +99,8 @@ module Docker::Compose
     end
 
     # Take the stack down
-    def down
-      run!('down')
+    def down(remove_volumes: false)
+      run!('down', opts(v: [!!remove_volumes, false]))
     end
 
     # Pull images of services

--- a/spec/docker/compose/session_spec.rb
+++ b/spec/docker/compose/session_spec.rb
@@ -91,6 +91,15 @@ describe Docker::Compose::Session do
     end
   end
 
+  describe '#down' do
+    it 'brings down containers' do
+      expect(shell).to receive(:run).with('docker-compose', 'down', {})
+      expect(shell).to receive(:run).with('docker-compose', 'down', hash_including(v:true))
+      session.down
+      session.down remove_volumes:true
+    end
+  end
+
   describe '#run' do
     it 'runs containers' do
       expect(shell).to receive(:run).with('docker-compose', 'run', {}, 'service1', [])


### PR DESCRIPTION
`docker-compose down` can take an argument to tell it to remove any docker volumes created in support of the current stack. This PR adds that functionality to `Docker::Compose::Session#down` (via `remove_volumes: true`).