### PR TITLE
Run `docker ps` with `--no-trunc` flag

### DIFF
--- a/lib/docker/compose/session.rb
+++ b/lib/docker/compose/session.rb
@@ -274,7 +274,7 @@ module Docker::Compose
     private
 
     def docker_ps(id)
-      cmd = @shell.run('docker', 'ps', a: true, f: "id=#{id}", format: Container::PS_FMT).join
+      cmd = @shell.run('docker', 'ps', a: true, f: "id=#{id}", no_trunc: true, format: Container::PS_FMT).join
       status, out, err = cmd.status, cmd.captured_output, cmd.captured_error
       raise Error.new('docker ps', status, out+err) unless status.success?
       lines = out.split(/[\r\n]+/)

--- a/spec/docker/compose/session_spec.rb
+++ b/spec/docker/compose/session_spec.rb
@@ -49,7 +49,7 @@ describe Docker::Compose::Session do
                      captured_output:"(#{h}) (xeger/#{h}:latest) (1.0MB (virtual 7.3MB)) (Up 1 second) (#{h}) () ()",
                      captured_error:'')
         allow(cmd).to receive(:join).and_return(cmd)
-        expect(shell).to receive(:run).with('docker', 'ps', hash_including(f:"id=#{h}")).and_return(cmd)
+        expect(shell).to receive(:run).with('docker', 'ps', hash_including(f:"id=#{h}",no_trunc:true)).and_return(cmd)
         allow(shell).to receive(:interactive=)
       end
     end


### PR DESCRIPTION
Necessary when containers have a lot of labels, and the `docker ps` output is long enough that it's truncated, and cannot be parsed.